### PR TITLE
enable variable table row heights for multi-line chat messages

### DIFF
--- a/Firechat/ViewController.h
+++ b/Firechat/ViewController.h
@@ -11,7 +11,7 @@
 #import <UIKit/UIKit.h>
 #import <Firebase/Firebase.h>
 
-@interface ViewController : UIViewController
+@interface ViewController : UIViewController <UITableViewDelegate, UITableViewDataSource>
 
 @property (nonatomic, strong) NSString* name;
 @property (nonatomic, strong) NSMutableArray* chat;

--- a/Firechat/ViewController.m
+++ b/Firechat/ViewController.m
@@ -78,6 +78,24 @@
     return [self.chat count];
 }
 
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    NSDictionary* chatMessage = [self.chat objectAtIndex:indexPath.row];
+    
+    NSString *text = chatMessage[@"text"];
+    
+    // typical textLabel.frame = {{10, 30}, {260, 22}}
+    const CGFloat TEXT_LABEL_WIDTH = 260;
+    CGSize constraint = CGSizeMake(TEXT_LABEL_WIDTH, 20000);
+    
+    // typical textLabel.font = font-family: "Helvetica"; font-weight: bold; font-style: normal; font-size: 18px
+    CGSize size = [text sizeWithFont:[UIFont systemFontOfSize:18] constrainedToSize:constraint lineBreakMode:NSLineBreakByWordWrapping]; // requires iOS 6+
+    const CGFloat CELL_CONTENT_MARGIN = 22;
+    CGFloat height = MAX(CELL_CONTENT_MARGIN + size.height, 44);
+    
+    return height;
+}
+
 - (UITableViewCell*)tableView:(UITableView*)table cellForRowAtIndexPath:(NSIndexPath *)index
 {
     static NSString *CellIdentifier = @"Cell";
@@ -85,6 +103,8 @@
     
     if (cell == nil) {
         cell = [[UITableViewCell alloc]initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:CellIdentifier];
+        cell.textLabel.font = [UIFont systemFontOfSize:18];
+        cell.textLabel.numberOfLines = 0;
     }
     
     NSDictionary* chatMessage = [self.chat objectAtIndex:index.row];


### PR DESCRIPTION
long sentences were being truncated, making it impossible for
users to see what was said. now they are word wrapped.
